### PR TITLE
Fix macOS build

### DIFF
--- a/resources/config_bundles/macos/patch_order.list
+++ b/resources/config_bundles/macos/patch_order.list
@@ -1,6 +1,5 @@
 ungoogled-chromium/macos/disable-symbol-order-verification.patch
 ungoogled-chromium/macos/disable-crashpad-handler.patch
-ungoogled-chromium/macos/add-trknotify-gn-dependency.patch
 ungoogled-chromium/macos/fix-gn-bootstrap.patch
 ungoogled-chromium/macos/fix-gn-safe_browsing.patch
 ungoogled-chromium/macos/fix-mapped_file.patch


### PR DESCRIPTION
Build was failing because it couldn't find `//iridium:trknotify`. Not sure what that does, but I've managed to compile for version 65 by removing it from the macos patch order.